### PR TITLE
Set the correct relative path for font files

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -50,7 +50,7 @@ PDFJS.FontLoader.bind = function nodeFontLoaderBind(pdf, fonts, callback) {
     }
 
     var fontName = font.loadedName;
-    var fontFile = 'temp/' + pdf._idx + '_' + fontName + '.ttf';
+    var fontFile = __dirname + '/../temp/' + pdf._idx + '_' + fontName + '.ttf';
 
     // Temporary hack for loading the font. Write it to file such that a font
     // object can get created from it and use it on the context.


### PR DESCRIPTION
If I included this as a node module in a project, it threw errors because it couldn't find the TTF files in `temp/`. I updated the path to be the correct relative path using `__dirname` and now it works.
